### PR TITLE
Lrefinder report

### DIFF
--- a/config_files/json/module_data.json
+++ b/config_files/json/module_data.json
@@ -28,7 +28,8 @@
         "lissero_report.csv",
         "meningotype_report.csv",
         "legsta_report.csv",
-        "resfinder_mobtyper_mapping.csv"
+        "resfinder_mobtyper_mapping.csv",
+        "lrefinder_report.csv"
     ],
     "core": {
         "targets": [

--- a/config_files/json/module_data.json
+++ b/config_files/json/module_data.json
@@ -14,6 +14,7 @@
         "harmonized_resistance_profile.tsv",
         "software_log.csv",
         "mobtyper_summary.csv",
+        "mobtyper_contig_summary.csv",
         "plasmidfinder_summary.csv",
         "kleborate_report.csv",
         "kraken2contigs_report.csv",
@@ -26,7 +27,8 @@
         "sistr_report.csv",
         "lissero_report.csv",
         "meningotype_report.csv",
-        "legsta_report.csv"
+        "legsta_report.csv",
+        "resfinder_mobtyper_mapping.csv"
     ],
     "core": {
         "targets": [

--- a/config_files/yaml/cluster.yaml
+++ b/config_files/yaml/cluster.yaml
@@ -12,6 +12,7 @@ __default__:
   queue: "batch"
   jobout: "oe"
   outdir: "ardetype_job_logs/"
+  file: 2048
 
 
 ##############
@@ -63,9 +64,10 @@ classify_contigs:
 contig_assembly:
   jobname: "ardetype.contig_assembly"
   procs: 38
-  pmem: "2000mb"
+  pmem: "6000mb"
   walltime: "10:40:00"
   account: "rakus"
+  feature: "largescratch"
   queue: "batch"
   jobout: "oe"
   nodes: 1

--- a/config_files/yaml/config_modular.yaml
+++ b/config_files/yaml/config_modular.yaml
@@ -140,6 +140,7 @@ core_tool_configs:
     #24576
   shovill:
     minlen: 1
+    mincov: 0 #2
     cpus: 35
     ram: 100
     depth: 100

--- a/config_files/yaml/config_modular.yaml
+++ b/config_files/yaml/config_modular.yaml
@@ -9,6 +9,8 @@ databases:
   /mnt/beegfs2/home/groups/nmrl/db/
 status_script_path:
   /mnt/beegfs2/home/groups/nmrl/bact_analysis/Ardetype/subscripts/pbs-status.py
+ardetype_version:
+  v0.0.1-dev
 
 
 ##############

--- a/config_files/yaml/config_modular.yaml
+++ b/config_files/yaml/config_modular.yaml
@@ -10,7 +10,7 @@ databases:
 status_script_path:
   /mnt/beegfs2/home/groups/nmrl/bact_analysis/Ardetype/subscripts/pbs-status.py
 ardetype_version:
-  v0.0.1-dev
+  v0.1.0-dev
 
 
 ##############

--- a/snakefiles/bact_core
+++ b/snakefiles/bact_core
@@ -116,6 +116,7 @@ rule contig_assembly:
         singularity --silent exec --bind {config[output_directory]},{config[work_dir]}:{config[output_directory]},{config[work_dir]} {input.sif_file} shovill {config[core_tool_configs][shovill][modules]} \
         --depth {config[core_tool_configs][shovill][depth]} --ram {config[core_tool_configs][shovill][ram]} \
         --cpus {threads} --minlen {config[core_tool_configs][shovill][minlen]} \
+        --mincov {config[core_tool_configs][shovill][mincov]} \
         --force --outdir {config[output_directory]}{wildcards.sample_id_pattern}_contigs \
         --R1 {input.read_1} --R2 {input.read_2}
         """

--- a/snakefiles/bact_core
+++ b/snakefiles/bact_core
@@ -27,7 +27,7 @@ rule all:
             df         = df[df['taxid'] == "S"].reset_index(drop=True)                                          #extract only species rows
             top_hit    = df.loc[df["read_%"] ==df["read_%"].max()]['name'].reset_index(drop=True)[0].strip()    #extract top hit
             total_dict[
-                os.path.basename(file).replace("_kraken2_contigs_report.txt","")                                
+                os.path.basename(file).replace("_kraken2_contigs_report.txt","")                              
                 ]      = top_hit                                                                                #save info for current samples
         with open(config['output_directory']+'core_aggregated_taxonomy.json', "w+") as json_handle:             #write top hit for each sample to json file
             json.dump(total_dict, json_handle)
@@ -113,12 +113,22 @@ rule contig_assembly:
         'singularity'
     shell:
         """
-        singularity --silent exec --bind {config[output_directory]},{config[work_dir]}:{config[output_directory]},{config[work_dir]} {input.sif_file} shovill {config[core_tool_configs][shovill][modules]} \
+        FOLDER_NAME=/scratch/{wildcards.sample_id_pattern}_assembly_tmp_$(date +%Y-%m-%d_%H-%M-%S)
+        cleanup_scratch() {{
+            rm -rf $FOLDER_NAME
+        }}
+        trap cleanup_scratch EXIT
+        ulimit -n 2048
+        mkdir -m 775 $FOLDER_NAME
+        singularity --silent exec --bind ${{FOLDER_NAME}},{config[output_directory]},{config[work_dir]}:${{FOLDER_NAME}},{config[output_directory]},{config[work_dir]} {input.sif_file} shovill {config[core_tool_configs][shovill][modules]} \
         --depth {config[core_tool_configs][shovill][depth]} --ram {config[core_tool_configs][shovill][ram]} \
         --cpus {threads} --minlen {config[core_tool_configs][shovill][minlen]} \
         --mincov {config[core_tool_configs][shovill][mincov]} \
         --force --outdir {config[output_directory]}{wildcards.sample_id_pattern}_contigs \
-        --R1 {input.read_1} --R2 {input.read_2}
+        --R1 {input.read_1} --R2 {input.read_2}\
+        --tmpdir $FOLDER_NAME
+
+        rm -r $FOLDER_NAME
         """
 
 

--- a/snakefiles/bact_shape
+++ b/snakefiles/bact_shape
@@ -583,7 +583,7 @@ rule extract_SeroBA:
     run:
         try:
             key = "_seroba.tsv"
-            report = pd.read_csv(input[0], sep="\t", header=None)
+            report = pd.read_csv(input[0], sep="\t", header=None).astype(str)
             report.columns = ["id","type","info"]
             report = report[["type", "info"]]
             if isinstance(report['info'][0], str): report["type"] = report[["type", "info"]].agg('; '.join, axis=1) #textjoin in pandas accross columns

--- a/snakefiles/bact_shell
+++ b/snakefiles/bact_shell
@@ -2,6 +2,7 @@ localrules: all
 
 import pandas as pd, os, sys, json
 from Bio import SeqIO
+from pathlib import Path
 sys.path.insert(0, os.path.abspath('./'))
 from subscripts.ardetype_utilities import Ardetype_housekeeper as hk
 
@@ -63,13 +64,15 @@ rule all:
 
         #Lists of plasmid reports to aggregate
         plasmidfinder        = expand(config['output_directory']+'{sample_id}_plasmidfinder/results_tab.tsv', sample_id=sample_sheet['sample_id']),
-        mobtyper             = expand(config['output_directory']+'{sample_id}_mob_typer.tab', sample_id=sample_sheet['sample_id'])
+        mobtyper             = expand(config['output_directory']+'{sample_id}_mob_recon/mobtyper_results.txt', sample_id=sample_sheet['sample_id']),
+        mobtyper_contigs     = expand(config['output_directory']+'{sample_id}_mob_recon/contig_report.txt', sample_id=sample_sheet['sample_id'])
     run:
         #Use only non-empty files (hamronization fails otherwise or easier to implement custom aggregation)
         input.hamr_resfinder = [ path for path in input.hamr_resfinder if not os.path.getsize(path) == 0]
         input.hamr_rgi       = [ path for path in input.hamr_rgi if not os.path.getsize(path) == 0]
         input.hamr_amrfp     = [ path for path in input.hamr_amrfp if not os.path.getsize(path) == 0]
         input.amrfp_mut      = [ path for path in input.amrfp_mut if not os.path.getsize(path) == 0]
+        input.mobtyper       = [ path for path in input.mobtyper if not os.path.getsize(path) == 0]
 
         #Create single tsv report from all resistance inference tools
         os.system(f'''
@@ -100,6 +103,10 @@ rule all:
         mbt = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, extractor = hk.mobtyper_results, pathlist = input.mobtyper)
         mbt.to_csv(f"{config['output_directory']}mobtyper_summary.csv", header=True, index=False)
 
+        #Aggregate mob_typer_contig_info
+        mbtc = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, extractor = hk.mobtyper_contig_results, pathlist = input.mobtyper_contigs)
+        mbtc.to_csv(f"{config['output_directory']}mobtyper_contig_summary.csv", header=True, index=False)
+
         #Aggregate quast results
         qst = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, extractor = hk.quast_results, wildcard = "*quast/report.tsv")
         qst.to_csv(f"{config['output_directory']}quast_report.csv", header=True, index=False)
@@ -108,6 +115,15 @@ rule all:
         amfp = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, extractor = hk.amrfpm_results, pathlist = input.amrfp_mut)
         amfp.to_csv(f"{config['output_directory']}amrfp_mutation_report.csv", header=True, index=False)
 
+        #Search for AMR-plasmid associations in resfinder & mobtyper output
+        if not os.path.getsize(f"{config['output_directory']}mobtyper_contig_summary.csv") == 0:
+            hamr_pls = hk.hamr_plasmid_map(
+                hamr_report_path=f"{config['output_directory']}harmonized_resistance_profile.tsv",
+                mbt_contig_report_path=f"{config['output_directory']}mobtyper_contig_summary.csv")
+            hamr_pls.to_csv(f"{config['output_directory']}resfinder_mobtyper_mapping.csv", header=True, index=False)
+        else:
+            Path(f"{config['output_directory']}mobtyper_contig_summary.csv").touch()
+
 
 rule mob_recon:
     input:
@@ -115,12 +131,16 @@ rule mob_recon:
         contigs       = config['work_dir']+'{sample_id_pattern}_contigs.fasta'
     output:
         config['output_directory']+'{sample_id_pattern}_mob_recon/chromosome.fasta', #expected in any case, unless only plasmid was sequenced
-        config['output_directory']+'{sample_id_pattern}_mob_recon/contig_report.txt' #contig scanning results
+        config['output_directory']+'{sample_id_pattern}_mob_recon/contig_report.txt', #contig scanning results
+        config['output_directory']+'{sample_id_pattern}_mob_recon/mobtyper_results.txt'
     envmodules:
         'singularity'
     shell:
         """
         singularity --silent exec --bind {config[output_directory]},{config[work_dir]}:{config[output_directory]},{config[work_dir]} {input.mob_suite_sif} mob_recon --infile {input.contigs} --force --outdir {config[output_directory]}{wildcards.sample_id_pattern}_mob_recon/
+        if ! [ -f {output[2]} ]; then
+            touch {output[2]}
+        fi
         """
 
 

--- a/snakefiles/bact_shell
+++ b/snakefiles/bact_shell
@@ -84,7 +84,8 @@ rule all:
         #add output folder name as analysis batch id
         res_sum = pd.read_csv(f"{config['output_directory']}harmonized_resistance_profile.tsv", sep='\t')
         res_sum.input_file_name = res_sum.input_file_name.str.replace(r'_S[0-9]*', '', regex=True)
-        res_sum.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(config['output_directory'])) for _ in res_sum.index])
+        if 'analysis_batch_id' not in res_sum.columns:
+            res_sum.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(config['output_directory'])) for _ in res_sum.index])
         res_sum.to_csv(f"{config['output_directory']}harmonized_resistance_profile.tsv", sep='\t', header=True, index=False)
 
         #Aggregating resfinder phenotype info

--- a/snakefiles/bact_tip
+++ b/snakefiles/bact_tip
@@ -409,13 +409,16 @@ rule pasteur_pcr_serogroup_lmonocytogenes:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Listeria monocytogenes')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Listeria monocytogenes')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_lmonocytogenes:
@@ -426,13 +429,16 @@ rule pasteur_cgmlst_lmonocytogenes:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Listeria monocytogenes', scheme_num=1)
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)         
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Listeria monocytogenes', scheme_num=1)
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')     
 
 
 rule pasteur_cgmlst_nmeningitidis:
@@ -443,13 +449,16 @@ rule pasteur_cgmlst_nmeningitidis:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Neisseria meningitidis')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Neisseria meningitidis')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_ngonorrhoeae:
@@ -460,13 +469,16 @@ rule pasteur_cgmlst_ngonorrhoeae:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Neisseria gonorrhoeae', scheme_num=1)
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Neisseria gonorrhoeae', scheme_num=1)
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_kpneumoniae:
@@ -477,13 +489,16 @@ rule pasteur_cgmlst_kpneumoniae:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Klebsiella pneumoniae')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Klebsiella pneumoniae')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_saureus:
@@ -494,13 +509,16 @@ rule pasteur_cgmlst_saureus:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Staphylococcus aureus')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Staphylococcus aureus')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_senterica:
@@ -511,13 +529,16 @@ rule pasteur_cgmlst_senterica:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Salmonella enterica')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Salmonella enterica')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_ecoli:
@@ -528,13 +549,16 @@ rule pasteur_cgmlst_ecoli:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Escherichia coli')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Escherichia coli')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_spneumoniae:
@@ -545,13 +569,16 @@ rule pasteur_cgmlst_spneumoniae:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Streptococcus pneumoniae')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Streptococcus pneumoniae')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule pasteur_cgmlst_abaumanii:
@@ -562,13 +589,16 @@ rule pasteur_cgmlst_abaumanii:
     run:
         filtered_contigs = input.contigs.replace("_contigs.fasta", "_filtered_contigs.fasta")
         hk.filter_contigs_length(input.contigs, filtered_contigs)
-        api_output = hk.type_contigs_api(filtered_contigs, 'Acinetobacter baumanii', scheme_num=1)
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-            os.remove(filtered_contigs)
-        else:
-            os.system(f"touch {output[0]}")
-            os.remove(filtered_contigs)
+        try:
+            api_output = hk.type_contigs_api(filtered_contigs, 'Acinetobacter baumanii', scheme_num=1)
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+                os.remove(filtered_contigs)
+            else:
+                os.system(f"touch {output[0]}")
+                os.remove(filtered_contigs)
+        except:
+            os.system(f'touch {output[0]}')
 
 
 rule publmst_ngonorrhoe:
@@ -577,11 +607,14 @@ rule publmst_ngonorrhoe:
     output:
         config['output_directory']+'{sample_id_pattern}_ngmast.json'
     run:
-        api_output = hk.type_contigs_api(input.contigs, 'Neisseria gonorrhoeae')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-        else:
-            os.system(f"touch {output[0]}")
+        try:
+            api_output = hk.type_contigs_api(input.contigs, 'Neisseria gonorrhoeae')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+            else:
+                os.system(f"touch {output[0]}")
+        except:
+            os.system(f'touch {output[0]}')
         
 
 rule pubmlst_abaumanii:
@@ -590,12 +623,15 @@ rule pubmlst_abaumanii:
     output:
         config['output_directory']+'{sample_id_pattern}_ab_pumblst.json'
     run:
-        api_output = hk.type_contigs_api(input.contigs, 'Acinetobacter baumanii')
-        if isinstance(api_output, dict):
-            hk.write_json(api_output, output[0])
-        else:
-            os.system(f"touch {output[0]}")
-
+        try:
+            api_output = hk.type_contigs_api(input.contigs, 'Acinetobacter baumanii')
+            if isinstance(api_output, dict):
+                hk.write_json(api_output, output[0])
+            else:
+                os.system(f"touch {output[0]}")
+        except:
+            os.system(f'touch {output[0]}')
+            
 
 rule ectyper_ecoli:
     input:

--- a/snakefiles/bact_tip
+++ b/snakefiles/bact_tip
@@ -90,6 +90,10 @@ rule all:
         legsta_summary = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, wildcard = "*legsta.csv", extractor = hk.legsta_results)
         legsta_summary.to_csv(f"{config['output_directory']}legsta_report.csv", header=True, index=False)
 
+        #Aggregate LRE-Finder results
+        lrefinder_summary = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, wildcard = "*_lrefinder/*.pos", extractor = hk.lrefinder_results)
+        lrefinder_summary.to_csv(f"{config['output_directory']}lrefinder_report.csv", header=True, index=False)
+
         #Run cluster analysis
         hk.cgmlst_cluster_analysis(
             path = config['output_directory'],

--- a/snakefiles/bact_tip
+++ b/snakefiles/bact_tip
@@ -89,6 +89,13 @@ rule all:
         legsta_summary = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, wildcard = "*legsta.csv", extractor = hk.legsta_results)
         legsta_summary.to_csv(f"{config['output_directory']}legsta_report.csv", header=True, index=False)
 
+        #Run cluster analysis
+        hk.cgmlst_cluster_analysis(
+            path = config['output_directory'],
+            wildcard='*_chewbbaca/results_alleles.tsv',
+            thresholds=[i+1 for i in range(25)],
+            log_scale=True,
+            rem_outlier=100)
 
 rule hicap_hinfluenzae:
     input:

--- a/subscripts/ardetype_modules.py
+++ b/subscripts/ardetype_modules.py
@@ -194,6 +194,7 @@ class Wrapper():
                 db_map[t] = Wrapper._db_vers_map[t]
         df['db_versions'] = df['tool'].map(db_map)
         df.insert(0, 'analysis_batch_id', [os.path.basename(os.path.dirname(output_path)) for _ in df.index])
+        df['ardetype_version'] = Wrapper._config_dict['ardetype_version']
         df.to_csv(os.path.join(output_path, 'software_log.csv'), header=True, index=False)
 
 

--- a/subscripts/ardetype_modules.py
+++ b/subscripts/ardetype_modules.py
@@ -246,6 +246,7 @@ class Ardetype_module(Module):
             if os.path.basename(os.path.dirname(self.output_path)) == os.path.dirname(self.input_path):
                 self.input_path = os.path.dirname(new_path)
             self.output_path         = new_path
+
             
 
     def config_cluster(self) -> None:

--- a/subscripts/ardetype_utilities.py
+++ b/subscripts/ardetype_utilities.py
@@ -331,6 +331,15 @@ class Ardetype_housekeeper(hk):
         df.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(batch)) for _ in df.index])
         return df
 
+    @staticmethod
+    def lrefinder_results(lrefinder_pos_path:str, batch: str):
+        '''To combine lrefinder mutation reports and map them to sample_id-batch pair.'''
+        df = pd.read_csv(lrefinder_pos_path, sep='\t')
+        sample_id = re.sub(r'_S[0-9]*.pos', '', os.path.basename(lrefinder_pos_path))
+        df.insert(0, 'sample_id', [sample_id for _ in df.index])
+        df.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(batch)) for _ in df.index])
+        return df
+
 ####################
 #Special aggregation
 ####################

--- a/subscripts/src/modules.py
+++ b/subscripts/src/modules.py
@@ -268,7 +268,7 @@ class Module:
         '''
         #job_submission command to be used by snakmake to automatically submit jobs to HPC; stuff in curly brackets are snakemake arguments, not python variables
         if os.path.basename(self.cluster_config_path) == 'cluster.yaml':
-            job_submission_command = '"qsub -N {cluster.jobname} -l nodes={cluster.nodes}:ppn={cluster.procs},pmem={cluster.pmem},walltime={cluster.walltime},feature={cluster.feature} -q {cluster.queue} -j {cluster.jobout} -o {cluster.outdir} -V"'
+            job_submission_command = '"qsub -N {cluster.jobname} -l nodes={cluster.nodes}:ppn={cluster.procs},pmem={cluster.pmem},walltime={cluster.walltime},feature={cluster.feature},file={cluster.file} -q {cluster.queue} -j {cluster.jobout} -o {cluster.outdir} -V"'
         elif os.path.basename(self.cluster_config_path) == 'cluster_slurm.yaml':
             job_submission_command = '"sbatch --job-name {cluster.jobname} -N {cluster.nodes} --ntasks={cluster.ppn} --mem-per-cpu={cluster.mempc} -t {cluster.time} -o {cluster.outdir}{cluster.output} -e {cluster.outdir}{cluster.error} --export=ALL"'
         else:

--- a/subscripts/src/modules.py
+++ b/subscripts/src/modules.py
@@ -65,7 +65,7 @@ class Module:
         self.retry_times         = retry_times #number of times snakemake will attempt to rerun failed jobs (default=3); used by run_module_cluster
         self.force_all           = "--forceall" if force_all else "" #to store forceall flag if it is supplied, else empty string is stored
         self.rule_graph          = f"--rulegraph | dot -Tpdf > {self.module_name}.pdf" if rule_graph else "" #to store rule_graph flag if it is supplied, else empty string is stored
-        self.unpack_output       = unpack_output #used to move files outside sample folders and do a rerun; used by unfold_output
+        self.unpack_output       = True if force_all else unpack_output #used to move files outside sample folders and do a rerun; used by unfold_output
         self.removed_samples     = pd.DataFrame() #to store dataframe containing information about samples that were deemed invalid by the module
         self.pack_output         = pack_output #switch to control putting output files into one folder named after sample_id; used by fold_output
         self.cleanup_dict        = {} #to map origin paths of input files to path in working directory; filled by move_to_wd; used by clear_working_directory


### PR DESCRIPTION
Added aggregation script for lrefinder results. Currently the LRE-Finder database contains only two resistance-conferring mutations for E.faecalis and E.faecium: 23S RNA G2505A and G2576T. The thresholds to infer resistance from reads is set to at least 10% of reads containing mutant type (default setting, configurable in db-lrefinder/elm.mutdist).
The results are aggregated in the following form:
| sample_id | batch_id | #Template  | pos | ref | A | C | G | T | N | - | A[%] | C[%] | G[%] | T[%] | N[%] | -[%] |
| --------- | -------- | ---------- | --- | --- | - | - | - | - | - | - | ---- | ---- | ---- | ---- | ---- | ---- |
| --------- | -------- | ---------- | --- | --- | - | - | - | - | - | - | ---- | ---- | ---- | ---- | ---- | ---- |
- #Template : name of the sequence in the database
- pos : position number
- ref : reference base
- A:count of reads with A at pos
- C   : count of reads with C at pos
- G   : count of reads with G at pos
- T   : count of reads with T at pos
- N   : count of reads with N at pos
- \-  : count of reads with: at pos
- A[%]: fraction of reads with A at pos
- C[%]: fraction of reads with C at pos
- G[%]: fraction of reads with G at pos
- T[%]: fraction of reads with T at pos
- N[%]: fraction of reads with N at pos
- \-[%]: fraction of reads with: at pos

### Tested on: 
- 230510_NDX550703_RUO_0076_AHCWJVBGXT
- Closes #5
### References
- https://bitbucket.org/genomicepidemiology/lre-finder/
- https://cge.food.dtu.dk/services/LRE-finder/