### PR TITLE
Added code to aggregate lrefinder_output

### DIFF
--- a/config_files/json/module_data.json
+++ b/config_files/json/module_data.json
@@ -28,7 +28,8 @@
         "lissero_report.csv",
         "meningotype_report.csv",
         "legsta_report.csv",
-        "resfinder_mobtyper_mapping.csv"
+        "resfinder_mobtyper_mapping.csv",
+        "lrefinder_report.csv"
     ],
     "core": {
         "targets": [

--- a/snakefiles/bact_tip
+++ b/snakefiles/bact_tip
@@ -90,6 +90,10 @@ rule all:
         legsta_summary = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, wildcard = "*legsta.csv", extractor = hk.legsta_results)
         legsta_summary.to_csv(f"{config['output_directory']}legsta_report.csv", header=True, index=False)
 
+        #Aggregate LRE-Finder results
+        lrefinder_summary = hk.aggregator(outfolder_path = config['output_directory'], proc_num = 6, wildcard = "*_lrefinder/*.pos", extractor = hk.lrefinder_results)
+        lrefinder_summary.to_csv(f"{config['output_directory']}lrefinder_report.csv", header=True, index=False)
+
         #Run cluster analysis
         hk.cgmlst_cluster_analysis(
             path = config['output_directory'],

--- a/subscripts/ardetype_utilities.py
+++ b/subscripts/ardetype_utilities.py
@@ -331,6 +331,15 @@ class Ardetype_housekeeper(hk):
         df.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(batch)) for _ in df.index])
         return df
 
+    @staticmethod
+    def lrefinder_results(lrefinder_pos_path:str, batch: str):
+        '''To combine lrefinder mutation reports and map them to sample_id-batch pair.'''
+        df = pd.read_csv(lrefinder_pos_path, sep='\t')
+        sample_id = re.sub(r'_S[0-9]*.pos', '', os.path.basename(lrefinder_pos_path))
+        df.insert(0, 'sample_id', [sample_id for _ in df.index])
+        df.insert(1, 'analysis_batch_id', [os.path.basename(os.path.dirname(batch)) for _ in df.index])
+        return df
+
 ####################
 #Special aggregation
 ####################


### PR DESCRIPTION
Added aggregation script for lrefinder results. Currently the LRE-Finder database contains only two resistance-conferring mutations for E.faecalis and E.faecium: 23S RNA G2505A and G2576T. The thresholds to infer resistance from reads is set to at least 10% of reads containing mutant type (default setting, configurable in db-lrefinder/elm.mutdist).
Closes #5. The results are aggregated in the following form:
| sample_id | batch_id | #Template  | pos | ref | A | C | G | T | N | - | A[%] | C[%] | G[%] | T[%] | N[%] | -[%] |
| --------- | -------- | ---------- | --- | --- | - | - | - | - | - | - | ---- | ---- | ---- | ---- | ---- | ---- |
| --------- | -------- | ---------- | --- | --- | - | - | - | - | - | - | ---- | ---- | ---- | ---- | ---- | ---- |
- #Template : name of the sequence in the database
- pos : position number
- ref : reference base
- A:count of reads with A at pos
- C   : count of reads with C at pos
- G   : count of reads with G at pos
- T   : count of reads with T at pos
- N   : count of reads with N at pos
- \-  : count of reads with: at pos
- A[%]: fraction of reads with A at pos
- C[%]: fraction of reads with C at pos
- G[%]: fraction of reads with G at pos
- T[%]: fraction of reads with T at pos
- N[%]: fraction of reads with N at pos
- \-[%]: fraction of reads with: at pos

### Tested on 230510_NDX550703_RUO_0076_AHCWJVBGXT

### References
- https://bitbucket.org/genomicepidemiology/lre-finder/
- https://cge.food.dtu.dk/services/LRE-finder/